### PR TITLE
Pin matplotlib to 2.2.4 lts.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ geojson
 shapely
 pyproj
 matplotlib-scalebar
+matplotlib==2.2.4


### PR DESCRIPTION
Hey,

I was trying to get your visualize example to work and ran into a couple of issues, this being the first one :)

With version 2.1 the function 'is_string_like' was deprecated, with
version 3.0.0 it was removed entirely.

* https://github.com/matplotlib/matplotlib/issues/7835/
* https://matplotlib.org/3.0.0/api/api_changes.html

As a first stop I propose pinning matplotlib to 2.2.4.

Cheers 
Philipp 