### PR TITLE
Pin geojson version to 1.3.5:

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Cython
 six
 geoindex
 osmread
-geojson
+geojson==1.3.5
 shapely
 pyproj
 matplotlib-scalebar


### PR DESCRIPTION
Hey,

With geojson version 2.0.0 the function 'is_valid' was removed.

* https://github.com/jazzband/python-geojson/pull/98
* https://github.com/jazzband/python-geojson/blob/master/CHANGELOG.rst#200-2017-07-28

I have only tested this with the unittest, I didn't run into this problem while playing with the library.

Together with PR: #19 and #18 all test pass :) 

Cheers,

Philipp