### PR TITLE
Fix test_exports: use obj.is_valid.

### DIFF
--- a/gtfspy/test/test_exports.py
+++ b/gtfspy/test/test_exports.py
@@ -240,10 +240,13 @@ class ExportsTest(unittest.TestCase):
         in_memory_file = io.StringIO()
         exports.write_stops_geojson(self.gtfs, in_memory_file)
         in_memory_file.seek(0)
-        self.assertTrue(geojson.is_valid(in_memory_file.read(-1)))
-        in_memory_file.seek(0)
+
         gjson = geojson.loads(in_memory_file.read(-1))
+
+        self.assertTrue(gjson.is_valid)
+
         gjson_properties = gjson['features'][0]['properties']
+
         self.assertIn("name", gjson_properties.keys())
         self.assertIn("stop_I", gjson_properties.keys())
 
@@ -251,10 +254,13 @@ class ExportsTest(unittest.TestCase):
         in_memory_file = io.StringIO()
         exports.write_sections_geojson(self.gtfs, in_memory_file)
         in_memory_file.seek(0)
-        self.assertTrue(geojson.is_valid(in_memory_file.read(-1)))
-        in_memory_file.seek(0)
+
         gjson = geojson.loads(in_memory_file.read(-1))
+
+        self.assertTrue(gjson.is_valid)
+
         gjson_properties = gjson['features'][0]['properties']
+
         self.assertIn("from_stop_I", gjson_properties.keys())
         self.assertIn("to_stop_I", gjson_properties.keys())
         self.assertIn("n_vehicles", gjson_properties.keys())
@@ -266,10 +272,13 @@ class ExportsTest(unittest.TestCase):
         in_memory_file = io.StringIO()
         exports.write_routes_geojson(self.gtfs, in_memory_file)
         in_memory_file.seek(0)
-        self.assertTrue(geojson.is_valid(in_memory_file.read(-1)))
-        in_memory_file.seek(0)
+
         gjson = geojson.loads(in_memory_file.read(-1))
+
+        self.assertTrue(gjson.is_valid)
+
         gjson_properties = gjson['features'][0]['properties']
+
         self.assertIn("route_type", gjson_properties.keys())
         self.assertIn("route_I", gjson_properties.keys())
         self.assertIn("route_name", gjson_properties.keys())


### PR DESCRIPTION
Hey,

I looked into where `geojson.is_valid` was used, it appears it was only used in three tests, I changed them to use the new method.

This is an alternative to #20, please consider both and choose the one you prefer :) 


The geojson library removed the geojson.is_valid function with version
2.0.0.

* https://github.com/jazzband/python-geojson/blob/master/CHANGELOG.rst#200-2017-07-28
* https://github.com/jazzband/python-geojson/pull/98

This combined with #19 makes all test pass.

Cheers, 

Philipp