### PR TITLE
Link setup.py requirements from requirement.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools>=18.0
 pandas
 networkx==1.11
 pyshp
@@ -6,8 +7,8 @@ nose
 Cython
 six
 geoindex
-osmread
-geojson
+osmread==0.2
+geojson>=2.0.0
 shapely
 pyproj
-matplotlib-scalebar
+matplotlib-scalebar==0.6.1

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
+import os
 from setuptools import setup, Extension, find_packages
 
 version="0.0.4"
+
+requirementstxt = os.path.join(os.path.dirname(__file__), 'requirements.txt')
+requirements = open(requirementstxt).read().strip().split('\n')
 
 setup(
     name="gtfspy",
@@ -31,22 +35,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5'
     ], 
-    install_requires = [
-        "setuptools>=18.0",
-        "pandas",
-        "networkx==1.11",
-        "pyshp",
-        "smopy",
-        "nose",
-        "Cython",
-        "six",
-        "geoindex",
-        "osmread==0.2",
-        "shapely",
-        "geojson>=2.0.0",
-        "pyproj",
-        "matplotlib-scalebar==0.6.1"
-    ],
+    install_requires = requirements,
     ext_modules=[
         Extension(
             'gtfspy.routing.label',


### PR DESCRIPTION
- This eliminates two copies of almost the same info.
- For a project used as a library, I think this makes sense.  Python
  docs imply requirement.txt is for end-user projects, but that's not
  how I have usually seen it used...
- I went with the copy in setup.py as the "true" copy.